### PR TITLE
fix：新增uri判断以修复releaseCapture接口调用导致的报错

### DIFF
--- a/harmony/view_shot/src/main/ets/ViewShotTurboModule.ts
+++ b/harmony/view_shot/src/main/ets/ViewShotTurboModule.ts
@@ -123,6 +123,9 @@ export class ViewShotTurboModule extends TurboModule {
   }
 
   releaseCapture(uri: string) {
+    if(!uri.startsWith('file://')){
+      return;
+    }
     let file = fs.openSync(uri, fs.OpenMode.READ_WRITE);
     let path = file.path;
     if (path == null) {


### PR DESCRIPTION
# Summary

Closes #14  
导致报错原因是capture内部调用了releaseCapture接口，releaseCapture接口未做uri判断，开发者传入base64字符串会导致接口报错，增加uri判断解决该问题。

## Checklist

- [X] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)