### PR TITLE
fix: 修复releaseCapture接口无效问题

### DIFF
--- a/harmony/view_shot/src/main/ets/ViewShotTurboModule.ts
+++ b/harmony/view_shot/src/main/ets/ViewShotTurboModule.ts
@@ -107,23 +107,21 @@ export class ViewShotTurboModule extends TurboModule {
   }
 
   releaseCapture(uri: string) {
-    if (!uri.startsWith('file://')) {
+    if (!uri.startsWith('/data')) {
       return;
     }
     let file = fs.openSync(uri, fs.OpenMode.READ_WRITE);
     let path = file.path;
-    if (path == null) {
+    if (path === null) {
       return;
     }
     fs.access(path).then((res: boolean) => {
-      if (!res) {
-        return;
-      }
-      if (file.getParent() == this.ctx.uiAbilityContext.cacheDir) {
-        fs.unlinkSync(path);
+      if(res){
+        if (file.getParent() === this.ctx.uiAbilityContext.tempDir) {
+          fs.unlinkSync(path);
+        }
       }
     })
-    fs.closeSync(file);
   }
 
   savePhotoOnDevice(title: string, option: Options, pixmap: image.PixelMap): Promise<string> {


### PR DESCRIPTION
# Summary

close #2 
修改路径判断，支持releaseCapture接口释放沙箱临时路径资源。

## Checklist

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)