### PR TITLE
fix：修复因未及时释放截图数据导致的内存泄漏问题

### DIFF
--- a/harmony/view_shot/src/main/ets/ViewShotTurboModule.ts
+++ b/harmony/view_shot/src/main/ets/ViewShotTurboModule.ts
@@ -145,6 +145,7 @@ export class ViewShotTurboModule extends TurboModule {
       imagePacker.packing(pixmap, packOpts).then(data => {
         fs.writeSync(file.fd, data);
         fs.closeSync(file);
+        pixmap.release();
         resolve(path);
       }).catch((error: BusinessError) => {
         Logger.error(`componentSnapshot failed, message = ${error}`);
@@ -176,6 +177,7 @@ export class ViewShotTurboModule extends TurboModule {
     let base64Helper = new util.Base64Helper();
     let uint8Arr = new Uint8Array(readBuffer);
     let base64Text = base64Helper.encodeToStringSync(uint8Arr);
+    pixmap.release();
     if (options.result === 'data-uri') {
       let dataUriStr = `data:image/${options.format};base64,${base64Text}`;
       return dataUriStr;


### PR DESCRIPTION
# Summary

closes #38 
及时释放截图数据，减少内存占用。

## Checklist

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)