### PR TITLE
调用getNativeNodeIdByTag框架接口根据tag获取组件ID

### DIFF
--- a/harmony/view_shot/src/main/ets/ViewShotTurboModule.ts
+++ b/harmony/view_shot/src/main/ets/ViewShotTurboModule.ts
@@ -53,7 +53,17 @@ export class ViewShotTurboModule extends TurboModule {
 
   captureRef(tag: number, option: Options): Promise<string> {
     return new Promise<string>((resolve, reject) => {
-      componentSnapshot.get(tag + '').then((pixmap: image.PixelMap) => {
+      let id
+      if (this.ctx.rnInstance["getNativeNodeIdByTag"] !== undefined && typeof this.ctx.rnInstance["getNativeNodeIdByTag"] === "function") {
+        id = JSON.parse(JSON.stringify(this.ctx.rnInstance["getNativeNodeIdByTag"](tag)));
+        if (typeof id === "object") {
+           id = id.ok
+        }
+      } else {
+        let id = tag + ''
+      }
+
+      componentSnapshot.get(id).then((pixmap: image.PixelMap) => {
         let originImageInfo: Size = pixmap.getImageInfoSync().size;
         let dstX = option.width ?? originImageInfo.width;
         let dstY = option.height ?? originImageInfo.height;

--- a/src/NativeModule.js
+++ b/src/NativeModule.js
@@ -1,8 +1,8 @@
 // @flow
-import { NativeModules } from 'react-native';
+import { NativeModules, TurboModuleRegistry} from 'react-native';
 
 // @ts-ignore
-const isTurboModuleEnabled = global.__turboModuleProxy != null;
+const isTurboModuleEnabled = TurboModuleRegistry.get("ViewShotTurboModule") != null;
 
 const RNViewShot = isTurboModuleEnabled
   ? // eslint-disable-next-line @typescript-eslint/no-var-requires


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

- 这个 PR 解决了哪些 issues？请标记这些 issues，以便合并 PR 后这些 issues 将会被自动关闭。
问题：修复0.77版本无法截图
方案：
1、调用getNativeNodeIdByTag框架接口根据tag获取组件ID
2、 0.77版本移除__turboModuleProxy属性，使用TurboModuleRegistry.get判断是否使用turboModule

## Test Plan

展示代码的稳定性。例如：用来复现场景的命令输入和结果输出、测试用例的路径地址，或者附上截图和视频。


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

