### PR TITLE
refactor: 适配0.77，修改获取ArkUI组件id的方式

### DIFF
--- a/harmony/view_shot/src/main/ets/ViewShotTurboModule.ts
+++ b/harmony/view_shot/src/main/ets/ViewShotTurboModule.ts
@@ -53,7 +53,10 @@ export class ViewShotTurboModule extends TurboModule {
 
   captureRef(tag: number, option: Options): Promise<string> {
     return new Promise<string>((resolve, reject) => {
-      componentSnapshot.get(tag + '').then((pixmap: image.PixelMap) => {
+      const nodeId = (this.ctx && (this.ctx as any).rnInstance && (this.ctx as any).rnInstance.getNativeNodeIdByTag)
+        ? (this.ctx as any).rnInstance.getNativeNodeIdByTag(tag) ?? (tag + '')
+        : (tag + '');
+      componentSnapshot.get(nodeId).then((pixmap: image.PixelMap) => {
         let originImageInfo: Size = pixmap.getImageInfoSync().size;
         let dstX = option.width ?? originImageInfo.width;
         let dstY = option.height ?? originImageInfo.height;

--- a/src/NativeModule.js
+++ b/src/NativeModule.js
@@ -2,7 +2,7 @@
 import { NativeModules } from 'react-native';
 
 // @ts-ignore
-const isTurboModuleEnabled = global.__turboModuleProxy != null;
+const isTurboModuleEnabled = global.nativeModuleProxy != null;
 
 const RNViewShot = isTurboModuleEnabled
   ? // eslint-disable-next-line @typescript-eslint/no-var-requires


### PR DESCRIPTION
# Summary

- 适配0.77，修改获取ArkUI组件id的方式。

## Test Plan

<img width="416" height="894" alt="image" src="https://github.com/user-attachments/assets/e7cf1860-469d-478c-940f-7d1a20f4bbc6" />


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)

<!-- Check completed item, when applicable, via: [X] -->

